### PR TITLE
expands the me query and schema

### DIFF
--- a/src/graphql/resolvers/queries/index.js
+++ b/src/graphql/resolvers/queries/index.js
@@ -1,6 +1,7 @@
 import root from './root';
 
 import { fieldResolvers as sessionsFields } from './sessions';
+import { fieldResolvers as meFields } from './me';
 
 export default {
   ...root,
@@ -8,4 +9,5 @@ export default {
 
 export const fieldResolvers = {
   ...sessionsFields,
+  ...meFields,
 };

--- a/src/graphql/resolvers/queries/me.js
+++ b/src/graphql/resolvers/queries/me.js
@@ -1,0 +1,28 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable import/prefer-default-export */
+import debug from 'debug';
+
+import sessionStore from '../../../dataSources/cloudFirestore/session';
+
+const dlog = debug('that:api:sessions:me');
+
+export const fieldResolvers = {
+  MeQuery: {
+    all: async (_, __, { dataSources: { firestore, logger }, user }) => {
+      dlog('my all called');
+      return sessionStore(firestore, logger).findMy({ user });
+    },
+    session: async (
+      _,
+      { id },
+      { dataSources: { firestore, logger }, user },
+    ) => {
+      dlog('my session called');
+
+      return sessionStore(firestore, logger).findMySession({
+        user,
+        sessionId: id,
+      });
+    },
+  },
+};

--- a/src/graphql/resolvers/queries/sessions.js
+++ b/src/graphql/resolvers/queries/sessions.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 /* eslint-disable import/prefer-default-export */
 import debug from 'debug';
 
@@ -12,20 +13,20 @@ export const fieldResolvers = {
       { year },
       { dataSources: { firestore, logger } },
     ) => {
-      dlog('SessionQuery:sessions called');
+      dlog('accepted called');
       throw new Error('not implemented yet');
     },
-    all: async (parent, { year }, { dataSources: { firestore, logger } }) => {
-      dlog('SessionQuery:sessions called');
+    all: (parent, { year }, { dataSources: { firestore, logger } }) => {
+      dlog('all called');
       throw new Error('not implemented yet');
     },
-    me: async (parent, args, { dataSources: { firestore, logger }, user }) => {
-      dlog('SessionQuery:sessions called');
+    me: (parent, args, { dataSources: { firestore, logger }, user }) => {
+      dlog('me called');
 
-      return sessionStore(firestore, logger).findMy({ user });
+      return {};
     },
-    session: async (parent, args, { dataSources: { firestore, logger } }) => {
-      dlog('SessionQuery:sessions called');
+    session: (parent, args, { dataSources: { firestore, logger } }) => {
+      dlog('session called');
       throw new Error('not implemented yet');
     },
   },

--- a/src/graphql/typeDefs/dataTypes/session.graphql
+++ b/src/graphql/typeDefs/dataTypes/session.graphql
@@ -1,6 +1,7 @@
 "Session"
 type Session @key(fields: "id") {
   id: ID!
+  eventId: ID!
   speakers: [Profile]
 
   title: String!

--- a/src/graphql/typeDefs/queries/meQuery.graphql
+++ b/src/graphql/typeDefs/queries/meQuery.graphql
@@ -1,0 +1,4 @@
+type MeQuery {
+  all: [Session] @auth(requires: "sessions")
+  session(id: ID!): Session @auth(requires: "sessions")
+}

--- a/src/graphql/typeDefs/queries/sessionsQuery.graphql
+++ b/src/graphql/typeDefs/queries/sessionsQuery.graphql
@@ -6,7 +6,7 @@ type SessionsQuery {
   all(year: Int): [Session] @auth(requires: "admin")
 
   "will return the sessions associated to the logged in user"
-  me: [Session] @auth(requires: "sessions")
+  me: MeQuery @auth(requires: "sessions")
 
   "will return an accepted session by it's id"
   session(id: ID!): Session


### PR DESCRIPTION
the `me` query became a query type. me now has children queries under it.

get all sessions for a userid
```
query getMySessions {
  sessions {
    me {
      all {
        id
        title        
      }
    }
  }
}
```

get a 1 session by id for your userId
```
query getSessionById($sessionId: ID!) {
  sessions {
    me {
      session(id: $sessionId) {
        id
        title
      }
    }
  }
}
```