### PR TITLE
adding enum descriptions for the ui

### DIFF
--- a/src/graphql/typeDefs/dataTypes/enums/assetLinkType.graphql
+++ b/src/graphql/typeDefs/dataTypes/enums/assetLinkType.graphql
@@ -1,18 +1,35 @@
+"assest links, description text is used in ui"
 enum AssetLinkType {
+  "LinkedIn"
   LINKEDIN
+  "GitHub"
   GITHUB
+  "YouTube"
   YOUTUBE
+  "Instagram"
   INSTAGRAM
+  "Twitter"
   TWITTER
+  "Facebook"
   FACEBOOK
+  "Twitch"
   TWITCH
+  "TikTok"
   TICTOK
+  "dev.to"
   DEV_TO
+  "Dribbble"
   DRIBBBLE
+  "Medium"
   MEDIUM
+  "Stack Overflow"
   STACK_OVERFLOW
+  "Website"
   WEBSITE
+  "File"
   FILE
+  "Document"
   DOCUMENT
+  "Image"
   IMAGE
 }

--- a/src/graphql/typeDefs/dataTypes/enums/category.graphql
+++ b/src/graphql/typeDefs/dataTypes/enums/category.graphql
@@ -1,5 +1,9 @@
+"category, description text is used in ui"
 enum Category {
+  "Professional"
   PROFESSIONAL
+  "Family"
   FAMILY
+  "Partner"
   PARTNER
 }

--- a/src/graphql/typeDefs/dataTypes/enums/entityType.graphql
+++ b/src/graphql/typeDefs/dataTypes/enums/entityType.graphql
@@ -1,7 +1,13 @@
+"entity types, description text is used in ui"
 enum EntityType {
+  "Partner"
   PARTNER
+  "Event"
   EVENT
+  "Community"
   COMMUNITY
+  "Member"
   MEMBER
+  "Session"
   SESSION
 }

--- a/src/graphql/typeDefs/dataTypes/enums/mentorship.graphql
+++ b/src/graphql/typeDefs/dataTypes/enums/mentorship.graphql
@@ -1,5 +1,9 @@
+"mentorship, description text is used in ui"
 enum Mentorship {
+  "None, I've got this."
   NO
+  "Some would be helpful."
   SOME
+  "All I can get."
   YES
 }

--- a/src/graphql/typeDefs/dataTypes/enums/sessionCategory.graphql
+++ b/src/graphql/typeDefs/dataTypes/enums/sessionCategory.graphql
@@ -1,22 +1,43 @@
+"session category, description text is used in ui"
 enum SessionCategory {
+  "Accessibility"
   ACCESSIBILITY
+  "Architecture"
   ARCHITECTURE
+  "AR/VR"
   AR_VR
+  "Cloud Computing"
   CLOUD_COMPUTING
+  "Database"
   DATABASE_STORAGE
+  "Design UX"
   DESIGN_UX
+  "DevOps"
   DEV_OPS
+  "Infrastructure"
   INFRASTRUCTURE
+  "IoT and Makers"
   IOT_MAKER
+  "Languages"
   LANGUAGES
+  "Machine Learning"
   MACHINE_LEARNING
+  "Mobile"
   MOBILE
+  "Product Management"
   PRODUCT_MANAGEMENT
+  "Soft Skills"
   SOFT_SKILLS
+  "Security"
   SECURITY
+  "Testing"
   TESTING
+  "Tooling"
   TOOLING
+  "User Interfaces"
   USER_INTERFACES
+  "Web"
   WEB
+  "Other"
   OTHER
 }

--- a/src/graphql/typeDefs/dataTypes/enums/sessionFilter.graphql
+++ b/src/graphql/typeDefs/dataTypes/enums/sessionFilter.graphql
@@ -1,4 +1,4 @@
-"filter view for returned sessions"
+"filter view for returned sessions, description text is used in ui"
 enum SessionFilter {
   "All sessions, no filtering"
   ALL

--- a/src/graphql/typeDefs/dataTypes/enums/sessionType.graphql
+++ b/src/graphql/typeDefs/dataTypes/enums/sessionType.graphql
@@ -1,9 +1,23 @@
+"session types, description text is used in ui"
 enum SessionType {
-  KEYNOTE
-  HALF_DAY_WORKSHOP
-  FULL_DAY_WORKSHOP
-  WORKSHOP
-  OPEN_SPACE
-  PANEL
+  "Regular, 60 minute presentation."
   REGULAR
+
+  "Keynote, 90 minute presentation."
+  KEYNOTE
+
+  "Half-day Workshop (pre-conference)."
+  HALF_DAY_WORKSHOP
+
+  "Full-day Workshop (pre-conference)."
+  FULL_DAY_WORKSHOP
+
+  "Workshop (pre-conference)."
+  WORKSHOP
+
+  "Open Space"
+  OPEN_SPACE
+
+  "Panel Session"
+  PANEL
 }

--- a/src/graphql/typeDefs/dataTypes/enums/status.graphql
+++ b/src/graphql/typeDefs/dataTypes/enums/status.graphql
@@ -1,11 +1,21 @@
+"session status, description text is used in ui"
 enum Status {
+  "Draft"
   DRAFT
+  "Submitted"
   SUBMITTED
+  "Accepted"
   ACCEPTED
+  "Not Accepted"
   NOT_ACCEPTED
+  "Withdrew"
   WITHDREW
+  "Wait List"
   WAIT_LIST
+  "Cancelled"
   CANCELLED
+  "Scheduled"
   SCHEDULED
+  "Archived"
   ARCHIVED
 }

--- a/src/graphql/typeDefs/dataTypes/enums/targetAudience.graphql
+++ b/src/graphql/typeDefs/dataTypes/enums/targetAudience.graphql
@@ -1,5 +1,9 @@
+"target audience, description text is used in ui"
 enum TargetAudience {
+  "Anybody"
   ANYBODY
+  "Developers"
   DEVELOPERS
+  "Managers"
   MANAGERS
 }


### PR DESCRIPTION
I'm adding descriptions to the enum values to be used by the UI. Rather than coming up with a complex key/value store, I will introspect against the schema and use the result as the label/value for the dropdown.

example: 
```
query getDropDownValues {
  targetAudience: __type(name: "TargetAudience") {
    enumValues {
      label: description
      value: name
    }
  }
}
```