### PR TITLE
change session name parameter with `session`

### DIFF
--- a/src/graphql/resolvers/mutations/adminSessionCreate.js
+++ b/src/graphql/resolvers/mutations/adminSessionCreate.js
@@ -47,7 +47,7 @@ export const fieldResolvers = {
   AdminSessionCreate: {
     openSpace: async (
       { eventId },
-      { openspace },
+      { session: openspace },
       {
         dataSources: {
           firestore,
@@ -79,7 +79,7 @@ export const fieldResolvers = {
     },
     keynote: async (
       { eventId },
-      { keynote },
+      { session: keynote },
       {
         dataSources: {
           firestore,
@@ -111,7 +111,7 @@ export const fieldResolvers = {
     },
     regular: async (
       { eventId },
-      { regular },
+      { session: regular },
       {
         dataSources: {
           firestore,
@@ -143,7 +143,7 @@ export const fieldResolvers = {
     },
     panel: async (
       { eventId },
-      { panel },
+      { session: panel },
       {
         dataSources: {
           firestore,
@@ -175,7 +175,7 @@ export const fieldResolvers = {
     },
     workshop: async (
       { eventId },
-      { workshop },
+      { session: workshop },
       {
         dataSources: {
           firestore,

--- a/src/graphql/resolvers/mutations/adminSessionUpdate.js
+++ b/src/graphql/resolvers/mutations/adminSessionUpdate.js
@@ -60,7 +60,7 @@ export const fieldResolvers = {
   AdminSessionUpdate: {
     openSpace: async (
       { sessionId },
-      { openspace },
+      { session: openspace },
       {
         dataSources: {
           firestore,
@@ -104,7 +104,7 @@ export const fieldResolvers = {
     },
     keynote: async (
       { sessionId },
-      { keynote },
+      { session: keynote },
       {
         dataSources: {
           firestore,
@@ -148,7 +148,7 @@ export const fieldResolvers = {
     },
     regular: async (
       { sessionId },
-      { regular },
+      { session: regular },
       {
         dataSources: {
           firestore,
@@ -192,7 +192,7 @@ export const fieldResolvers = {
     },
     panel: async (
       { sessionId },
-      { panel },
+      { session: panel },
       {
         dataSources: {
           firestore,
@@ -236,7 +236,7 @@ export const fieldResolvers = {
     },
     workshop: async (
       { sessionId },
-      { workshop },
+      { session: workshop },
       {
         dataSources: {
           firestore,

--- a/src/graphql/resolvers/mutations/sessionCreate.js
+++ b/src/graphql/resolvers/mutations/sessionCreate.js
@@ -77,7 +77,7 @@ export const fieldResolvers = {
     },
     openSpace: async (
       { eventId },
-      { openspace },
+      { session: openspace },
       {
         dataSources: {
           firestore,
@@ -109,7 +109,7 @@ export const fieldResolvers = {
     },
     keynote: async (
       { eventId },
-      { keynote },
+      { session: keynote },
       {
         dataSources: {
           firestore,
@@ -141,7 +141,7 @@ export const fieldResolvers = {
     },
     regular: async (
       { eventId },
-      { regular },
+      { session: regular },
       {
         dataSources: {
           firestore,
@@ -173,7 +173,7 @@ export const fieldResolvers = {
     },
     panel: async (
       { eventId },
-      { panel },
+      { session: panel },
       {
         dataSources: {
           firestore,
@@ -205,7 +205,7 @@ export const fieldResolvers = {
     },
     workshop: async (
       { eventId },
-      { workshop },
+      { session: workshop },
       {
         dataSources: {
           firestore,

--- a/src/graphql/resolvers/mutations/sessionUpdate.js
+++ b/src/graphql/resolvers/mutations/sessionUpdate.js
@@ -107,7 +107,7 @@ export const fieldResolvers = {
     },
     openSpace: async (
       { sessionId },
-      { openspace },
+      { session: openspace },
       {
         dataSources: {
           firestore,
@@ -163,7 +163,7 @@ export const fieldResolvers = {
     },
     keynote: async (
       { sessionId },
-      { keynote },
+      { session: keynote },
       {
         dataSources: {
           firestore,
@@ -206,7 +206,7 @@ export const fieldResolvers = {
     },
     regular: async (
       { sessionId },
-      { regular },
+      { session: regular },
       {
         dataSources: {
           firestore,
@@ -249,7 +249,7 @@ export const fieldResolvers = {
     },
     panel: async (
       { sessionId },
-      { panel },
+      { session: panel },
       {
         dataSources: {
           firestore,
@@ -292,7 +292,7 @@ export const fieldResolvers = {
     },
     workshop: async (
       { sessionId },
-      { workshop },
+      { session: workshop },
       {
         dataSources: {
           firestore,

--- a/src/graphql/typeDefs/mutations/adminSessionCreate.graphql
+++ b/src/graphql/typeDefs/mutations/adminSessionCreate.graphql
@@ -1,18 +1,18 @@
 type AdminSessionCreate {
   "Creates an OpenSpace type session"
-  openSpace(openspace: OpenSpaceAdminCreateInput!): OpenSpace!
+  openSpace(session: OpenSpaceAdminCreateInput!): OpenSpace!
     @auth(requires: "admin")
 
   "Creates a Keynote type session"
-  keynote(keynote: KeynoteAdminCreateInput!): Keynote! @auth(requires: "admin")
+  keynote(session: KeynoteAdminCreateInput!): Keynote! @auth(requires: "admin")
 
   "Creates a Regular type session"
-  regular(regular: RegularAdminCreateInput!): Regular! @auth(requires: "admin")
+  regular(session: RegularAdminCreateInput!): Regular! @auth(requires: "admin")
 
   "Creates a Workshop type session"
-  workshop(workshop: WorkshopAdminCreateInput!): Workshop!
+  workshop(session: WorkshopAdminCreateInput!): Workshop!
     @auth(requires: "admin")
 
   "Creates a panel type session"
-  panel(panel: PanelAdminCreateInput!): Panel! @auth(requires: "admin")
+  panel(session: PanelAdminCreateInput!): Panel! @auth(requires: "admin")
 }

--- a/src/graphql/typeDefs/mutations/adminSessionUpdate.graphql
+++ b/src/graphql/typeDefs/mutations/adminSessionUpdate.graphql
@@ -1,18 +1,18 @@
 type AdminSessionUpdate {
   "Update for an OpenSpace type session"
-  openSpace(openspace: OpenSpaceAdminUpdateInput!): OpenSpace!
+  openSpace(session: OpenSpaceAdminUpdateInput!): OpenSpace!
     @auth(requires: "admin")
 
   "Update for a Keynote type session"
-  keynote(keynote: KeynoteAdminUpdateInput!): Keynote! @auth(requires: "admin")
+  keynote(session: KeynoteAdminUpdateInput!): Keynote! @auth(requires: "admin")
 
   "Update for a Regular type session"
-  regular(regular: RegularAdminUpdateInput!): Regular! @auth(requires: "admin")
+  regular(session: RegularAdminUpdateInput!): Regular! @auth(requires: "admin")
 
   "Update for a Workshop type session"
-  workshop(workshop: WorkshopAdminUpdateInput!): Workshop!
+  workshop(session: WorkshopAdminUpdateInput!): Workshop!
     @auth(requires: "admin")
 
   "Update for a Panel type session"
-  panel(panel: PanelAdminUpdateInput!): Panel! @auth(requires: "admin")
+  panel(session: PanelAdminUpdateInput!): Panel! @auth(requires: "admin")
 }

--- a/src/graphql/typeDefs/mutations/sessionCreate.graphql
+++ b/src/graphql/typeDefs/mutations/sessionCreate.graphql
@@ -7,25 +7,27 @@ type SessionCreate {
     @deprecated(reason: "use specific session type create instead")
 
   "Creates an OpenSpace type session"
-  openSpace(openspace: OpenSpaceCreateInput!): OpenSpace!
+  openSpace(session: OpenSpaceCreateInput!): OpenSpace!
     @auth(requires: "sessions")
     @canMutate
 
   "Creates a Keynote type session"
-  keynote(keynote: KeynoteCreateInput!): Keynote!
+  keynote(session: KeynoteCreateInput!): Keynote!
     @auth(requires: "sessions")
     @canMutate
 
   "Creates a Regular type session"
-  regular(regular: RegularCreateInput!): Regular!
+  regular(session: RegularCreateInput!): Regular!
     @auth(requires: "sessions")
     @canMutate
 
   "Creates a Workshop type session"
-  workshop(workshop: WorkshopCreateInput!): Workshop!
+  workshop(session: WorkshopCreateInput!): Workshop!
     @auth(requires: "sessions")
     @canMutate
 
   "Creates a panel type session"
-  panel(panel: PanelCreateInput!): Panel! @auth(requires: "sessions") @canMutate
+  panel(session: PanelCreateInput!): Panel!
+    @auth(requires: "sessions")
+    @canMutate
 }

--- a/src/graphql/typeDefs/mutations/sessionUpdate.graphql
+++ b/src/graphql/typeDefs/mutations/sessionUpdate.graphql
@@ -7,25 +7,27 @@ type SessionUpdate {
     @deprecated(reason: "use specific session type update instead")
 
   "Update for an OpenSpace type session"
-  openSpace(openspace: OpenSpaceUpdateInput!): OpenSpace!
+  openSpace(session: OpenSpaceUpdateInput!): OpenSpace!
     @auth(requires: "sessions")
     @canMutate
 
   "Update for a Keynote type session"
-  keynote(keynote: KeynoteUpdateInput!): Keynote!
+  keynote(session: KeynoteUpdateInput!): Keynote!
     @auth(requires: "sessions")
     @canMutate
 
   "Update for a Regular type session"
-  regular(regular: RegularUpdateInput!): Regular!
+  regular(session: RegularUpdateInput!): Regular!
     @auth(requires: "sessions")
     @canMutate
 
   "Update for a Workshop type session"
-  workshop(workshop: WorkshopUpdateInput!): Workshop!
+  workshop(session: WorkshopUpdateInput!): Workshop!
     @auth(requires: "sessions")
     @canMutate
 
   "Update for a Panel type session"
-  panel(panel: PanelUpdateInput!): Panel! @auth(requires: "sessions") @canMutate
+  panel(session: PanelUpdateInput!): Panel!
+    @auth(requires: "sessions")
+    @canMutate
 }


### PR DESCRIPTION
Session mutations now use `session` as input parameter name for any type of session being mutated. 