### PR TITLE
CFP and Schedule updates

### DIFF
--- a/src/dataSources/cloudFirestore/session.js
+++ b/src/dataSources/cloudFirestore/session.js
@@ -241,6 +241,28 @@ function sessions(dbInstance) {
     );
   }
 
+  function findWithStatuses({ statuses, orderBy, eventId }) {
+    dlog('findWithStatuses, %o; orderby, %s', statuses, orderBy);
+    const inStatus = validateStatuses(statuses);
+    let startTimeOrder;
+    if (orderBy === 'START_TIME_ASC') startTimeOrder = 'asc';
+    else if (orderBy === 'START_TIME_DESC') startTimeOrder = 'desc';
+    let query = sessionsCol.where('status', 'in', inStatus);
+    if (eventId) query = query.where('eventId', '==', eventId);
+    if (startTimeOrder) query = query.orderBy('startTime', startTimeOrder);
+
+    return query.get().then(qrySnap => {
+      dlog('size of query result:: %d', qrySnap.size);
+      return qrySnap.docs.map(d => {
+        const r = {
+          id: d.id,
+          ...d.data(),
+        };
+        return sessionDateForge(r);
+      });
+    });
+  }
+
   async function findWithStatusesPaged({
     statuses,
     orderBy,
@@ -421,6 +443,7 @@ function sessions(dbInstance) {
     findSession,
     findAcceptedSession,
     batchFindSessions,
+    findWithStatuses,
     findWithStatusesPaged,
     addInAttendance,
     getTotalProfessionalSubmittedForEvent,

--- a/src/graphql/resolvers/queries/adminSessions.js
+++ b/src/graphql/resolvers/queries/adminSessions.js
@@ -1,0 +1,24 @@
+import debug from 'debug';
+import sessionStore from '../../../dataSources/cloudFirestore/session';
+
+const dlog = debug('that:api:sessions:querty:AdminSessions');
+
+export const fieldResolvers = {
+  AdminSessionsQuery: {
+    pullSchedule: () => {
+      throw new Error('Not Implemented yet');
+    },
+    all: (
+      _,
+      { eventId, status = ['APPROVED'], orderBy = 'START_TIME_ASC' },
+      { dataSources: { firestore } },
+    ) => {
+      dlog('all called with statuses %o, orderBy %s', status, orderBy);
+      return sessionStore(firestore).findWithStatuses({
+        statuses: status,
+        orderBy,
+        eventId,
+      });
+    },
+  },
+};

--- a/src/graphql/resolvers/queries/index.js
+++ b/src/graphql/resolvers/queries/index.js
@@ -3,7 +3,6 @@ import root from './root';
 import { fieldResolvers as sessionsFields } from './sessions';
 import { fieldResolvers as meFields } from './me';
 import { fieldResolvers as mySessionFields } from './mySession';
-
 import { fieldResolvers as votingFields } from './voting';
 import { fieldResolvers as acceptedSessionFields } from './acceptedSession';
 import { fieldResolvers as anonymizedSessionFields } from './anonymizedSession';
@@ -13,10 +12,10 @@ import { fieldResolvers as openSpaceFields } from './openSpace';
 import { fieldResolvers as keynoteFields } from './keynote';
 import { fieldResolvers as panelFields } from './panel';
 import { fieldResolvers as workshopFields } from './workshop';
-
 import { fieldResolvers as assetsFields } from './assets';
 import { fieldResolvers as assetFields } from './asset';
 import { fieldResolvers as entityFields } from './entity';
+import { fieldResolvers as adminFields } from './sessionAdminFields';
 
 export default {
   ...root,
@@ -38,4 +37,5 @@ export const fieldResolvers = {
   ...assetsFields,
   ...assetFields,
   ...entityFields,
+  ...adminFields,
 };

--- a/src/graphql/resolvers/queries/index.js
+++ b/src/graphql/resolvers/queries/index.js
@@ -16,6 +16,7 @@ import { fieldResolvers as assetsFields } from './assets';
 import { fieldResolvers as assetFields } from './asset';
 import { fieldResolvers as entityFields } from './entity';
 import { fieldResolvers as adminFields } from './sessionAdminFields';
+import { fieldResolvers as adminSessionsFields } from './adminSessions';
 
 export default {
   ...root,
@@ -38,4 +39,5 @@ export const fieldResolvers = {
   ...assetFields,
   ...entityFields,
   ...adminFields,
+  ...adminSessionsFields,
 };

--- a/src/graphql/resolvers/queries/keynote.js
+++ b/src/graphql/resolvers/queries/keynote.js
@@ -36,5 +36,6 @@ export const fieldResolvers = {
       dlog('session assets requested');
       return findAssets({ entityId, firestore, assetLoader });
     },
+    admin: parent => parent,
   },
 };

--- a/src/graphql/resolvers/queries/openSpace.js
+++ b/src/graphql/resolvers/queries/openSpace.js
@@ -36,5 +36,6 @@ export const fieldResolvers = {
       dlog('session assets requested');
       return findAssets({ entityId, firestore, assetLoader });
     },
+    admin: parent => parent,
   },
 };

--- a/src/graphql/resolvers/queries/panel.js
+++ b/src/graphql/resolvers/queries/panel.js
@@ -36,5 +36,6 @@ export const fieldResolvers = {
       dlog('session assets requested');
       return findAssets({ entityId, firestore, assetLoader });
     },
+    admin: parent => parent,
   },
 };

--- a/src/graphql/resolvers/queries/regular.js
+++ b/src/graphql/resolvers/queries/regular.js
@@ -36,5 +36,6 @@ export const fieldResolvers = {
       dlog('session assets requested');
       return findAssets({ entityId, firestore, assetLoader });
     },
+    admin: parent => parent,
   },
 };

--- a/src/graphql/resolvers/queries/sessionAdminFields.js
+++ b/src/graphql/resolvers/queries/sessionAdminFields.js
@@ -1,0 +1,5 @@
+export const fieldResolvers = {
+  SessionAdminFields: {
+    speakers: parent => parent.speakers.map(id => ({ id })),
+  },
+};

--- a/src/graphql/resolvers/queries/sessions.js
+++ b/src/graphql/resolvers/queries/sessions.js
@@ -45,5 +45,9 @@ export const fieldResolvers = {
         cursor,
       });
     },
+    admin: () => {
+      dlog('admin query path called');
+      return {};
+    },
   },
 };

--- a/src/graphql/resolvers/queries/theSessions.js
+++ b/src/graphql/resolvers/queries/theSessions.js
@@ -6,7 +6,6 @@ const dlog = debug('that:api:sessions:thesessions');
 export const fieldResolvers = {
   TheSessions: {
     __resolveType(obj, context, info) {
-      dlog('__resolveType called');
       let result = null;
       switch (obj.type) {
         case 'REGULAR':
@@ -28,8 +27,10 @@ export const fieldResolvers = {
           result = 'Workshop';
           break;
         default:
+          throw new Error(
+            `Resolver encountered unknown session type ${obj.type}`,
+          );
       }
-      dlog('result:', result);
       return result;
     },
   },

--- a/src/graphql/resolvers/queries/workshop.js
+++ b/src/graphql/resolvers/queries/workshop.js
@@ -36,5 +36,6 @@ export const fieldResolvers = {
       dlog('session assets requested');
       return findAssets({ entityId, firestore, assetLoader });
     },
+    admin: parent => parent,
   },
 };

--- a/src/graphql/typeDefs/dataTypes/enums/targetLocation.graphql
+++ b/src/graphql/typeDefs/dataTypes/enums/targetLocation.graphql
@@ -1,0 +1,8 @@
+enum TargetLocation {
+  "Online"
+  ONLINE
+  "In-Person"
+  IN_PERSON
+  "Either online or in-person"
+  EITHER
+}

--- a/src/graphql/typeDefs/dataTypes/inputs/keynoteInput.graphql
+++ b/src/graphql/typeDefs/dataTypes/inputs/keynoteInput.graphql
@@ -4,11 +4,12 @@ input KeynoteCreateInput {
   longDescription: String
 
   durationInMinutes: Int
-  startTime: Date
-  location: String
   tags: [String]
 
+  "The target audience for this session, professional, manager, kids, etc."
   targetAudience: [TargetAudience]
+  "The target location for this session, in-person, etc."
+  targetLocation: TargetLocation
   whyAreYou: String
   otherComments: String
 
@@ -35,11 +36,12 @@ input KeynoteUpdateInput {
 
   type: SessionType
   durationInMinutes: Int
-  startTime: Date
-  location: String
   tags: [String]
 
+  "The target audience for this session, professional, manager, kids, etc."
   targetAudience: [TargetAudience]
+  "The target location for this session, in-person, etc."
+  targetLocation: TargetLocation
   whyAreYou: String
   otherComments: String
 

--- a/src/graphql/typeDefs/dataTypes/inputs/openSpaceInput.graphql
+++ b/src/graphql/typeDefs/dataTypes/inputs/openSpaceInput.graphql
@@ -1,31 +1,32 @@
 input OpenSpaceCreateInput {
   title: String!
   shortDescription: String!
-
+  "The target audience for this session, professional, manager, kids, etc."
+  targetAudience: [TargetAudience]
+  "The target location for this session, in-person, etc."
+  targetLocation: TargetLocation
   durationInMinutes: Int
   startTime: Date
   location: String
   tags: [String]
-
   primaryCategory: SessionCategory
-
   status: Status
 }
 
 input OpenSpaceUpdateInput {
   title: String
   shortDescription: String
-
+  "The target audience for this session, professional, manager, kids, etc."
+  targetAudience: [TargetAudience]
+  "The target location for this session, in-person, etc."
+  targetLocation: TargetLocation
   type: SessionType
   durationInMinutes: Int
   startTime: Date
   location: String
   tags: [String]
-
   primaryCategory: SessionCategory
-
   status: Status
-
   "Member must have access to event to set/change"
   eventId: ID
 }

--- a/src/graphql/typeDefs/dataTypes/inputs/panelInput.graphql
+++ b/src/graphql/typeDefs/dataTypes/inputs/panelInput.graphql
@@ -4,11 +4,12 @@ input PanelCreateInput {
   longDescription: String
 
   durationInMinutes: Int
-  startTime: Date
-  location: String
   tags: [String]
 
+  "The target audience for this session, professional, manager, kids, etc."
   targetAudience: [TargetAudience]
+  "The target location for this session, in-person, etc."
+  targetLocation: TargetLocation
   whyAreYou: String
   otherComments: String
 
@@ -34,11 +35,12 @@ input PanelUpdateInput {
 
   type: SessionType
   durationInMinutes: Int
-  startTime: Date
-  location: String
   tags: [String]
 
+  "The target audience for this session, professional, manager, kids, etc."
   targetAudience: [TargetAudience]
+  "The target location for this session, in-person, etc."
+  targetLocation: TargetLocation
   whyAreYou: String
   otherComments: String
 

--- a/src/graphql/typeDefs/dataTypes/inputs/workshopInput.graphql
+++ b/src/graphql/typeDefs/dataTypes/inputs/workshopInput.graphql
@@ -4,11 +4,12 @@ input WorkshopCreateInput {
   longDescription: String
 
   durationInMinutes: Int
-  startTime: Date
-  location: String
   tags: [String]
 
+  "The target audience for this session, professional, manager, kids, etc."
   targetAudience: [TargetAudience]
+  "The target location for this session, in-person, etc."
+  targetLocation: TargetLocation
   whyAreYou: String
   otherComments: String
 
@@ -36,11 +37,12 @@ input WorkshopUpdateInput {
 
   type: SessionType
   durationInMinutes: Int
-  startTime: Date
-  location: String
   tags: [String]
 
+  "The target audience for this session, professional, manager, kids, etc."
   targetAudience: [TargetAudience]
+  "The target location for this session, in-person, etc."
+  targetLocation: TargetLocation
   whyAreYou: String
   otherComments: String
 

--- a/src/graphql/typeDefs/dataTypes/interfaces/base.graphql
+++ b/src/graphql/typeDefs/dataTypes/interfaces/base.graphql
@@ -17,6 +17,10 @@ interface Base {
   speakers: [PublicProfile]
   "The type of session, informs union resolver of session object to return"
   type: SessionType
+  "The target audience for this session, professional, manager, kids, etc."
+  targetAudience: [TargetAudience]
+  "The target location for this session, in-person, etc."
+  targetLocation: TargetLocation
   "Session status. ENUM. E.g. accepted, submitted, etc. "
   status: Status
   "Full duration of session in minutes"

--- a/src/graphql/typeDefs/dataTypes/interfaces/base.graphql
+++ b/src/graphql/typeDefs/dataTypes/interfaces/base.graphql
@@ -1,48 +1,46 @@
-"base session fields for any type of session"
+"Base session fields for any type of session"
 interface Base {
-  "session unique identifier"
+  # Start Base interface fields
+  "Session unique identifier"
   id: ID!
-  "event id session is associated with"
+  "Event id session is associated with"
   eventId: String!
-  "session slug unique by eventid"
+  "Session slug unique by eventId"
   slug: Slug!
-  "session title"
+  "The session's title"
   title: String!
-  "a shorter more concise desrcription"
+  "A shorter more concise description"
   shortDescription: String!
-  "primary category for the session"
+  "Primary interests category for the session"
   primaryCategory: SessionCategory
-  "associated speakers. will see session as their own"
+  "Session's associated speakers. Each will see session under their profile"
   speakers: [PublicProfile]
-
-  "the type of session, informs union resolver of session object to return"
+  "The type of session, informs union resolver of session object to return"
   type: SessionType
-  "session stats"
+  "Session status. ENUM. E.g. accepted, submitted, etc. "
   status: Status
-  "full duriation of session in munutes"
+  "Full duration of session in minutes"
   durationInMinutes: Int
-  "starting time of this session"
+  "Starting time of this session"
   startTime: Date
-  "location of session, physical or virtual"
+  "Location of session, physical or virtual"
   location: String
-
-  "tags to describe session"
+  "Tags to describe session"
   tags: [String]
   "Reference materials for all"
   supportingArtifacts: [Artifact]
-
-  "members with public profiles who favorited session"
+  "Members with public profiles who favorited session"
   favoritedBy: [PublicProfile]
-  "total number of members who favorited, includes non-public in count too"
+  "Total number of members who favorited, includes non-public in count too"
   favoriteCount: Int
-
-  "communities (as slug) associated with session. initially same as event community"
+  "Communities (as slug) associated with session. initially same as event community"
   communities: [Slug]
   "Assets assigned to this session"
   assets: [Asset]
-
-  "date time session created"
+  "Date time session created"
   createdAt: Date!
-  "date time session last updated"
+  "Date time session last updated"
   lastUpdatedAt: Date!
+  "Admin-specific fields"
+  admin: SessionAdminFields
 }

--- a/src/graphql/typeDefs/dataTypes/interfaces/eyesFront.graphql
+++ b/src/graphql/typeDefs/dataTypes/interfaces/eyesFront.graphql
@@ -1,27 +1,26 @@
-"session fields for eye-forward style sessions. Base must be implemented with EyesFront in types using this interface"
+"Session fields for eye-forward style sessions. Base must be implemented with EyesFront in types using this interface"
 interface EyesFront {
   # Start EyesFront interface fields
   "a longer more verbose session description"
   longDescription: String
   "why are you the best person to perform this session"
   whyAreYou: String
-
+  "other author comments regarding session"
   otherComments: String
-  "expected takeaways for attending this session"
+  "list of expected takeaways for attending this session"
   takeaways: [String]
-
   "does the speaker(s) require mentorship on this session?"
   mentorship: Mentorship
-  "secondary categories for the session"
+  "secondary interests categories for the session"
   secondaryCategory: [SessionCategory]
   "does the speaker(s) allow session to be recorded"
   canRecord: Boolean
   "session being recorded if set true"
   isRecorded: Boolean
-
+  "FUTURE: possible rating holder"
   rating: [Rating]
   "type of audience session is targeted toward"
   targetAudience: [TargetAudience]
-
+  "Main category declaration. e.g. professional, family, etc."
   category: Category
 }

--- a/src/graphql/typeDefs/dataTypes/interfaces/eyesFront.graphql
+++ b/src/graphql/typeDefs/dataTypes/interfaces/eyesFront.graphql
@@ -19,8 +19,6 @@ interface EyesFront {
   isRecorded: Boolean
   "FUTURE: possible rating holder"
   rating: [Rating]
-  "type of audience session is targeted toward"
-  targetAudience: [TargetAudience]
-  "Main category declaration. e.g. professional, family, etc."
+  "Main category/track declaration. e.g. professional, family, etc."
   category: Category
 }

--- a/src/graphql/typeDefs/dataTypes/session/acceptedSession.graphql
+++ b/src/graphql/typeDefs/dataTypes/session/acceptedSession.graphql
@@ -13,7 +13,10 @@ type AcceptedSession @key(fields: "id") {
   type: SessionType
   category: Category
   durationInMinutes: Int
+  "The target audience for this session, professional, manager, kids, etc."
   targetAudience: [TargetAudience]
+  "The target location for this session, in-person, etc."
+  targetLocation: TargetLocation
   whyAreYou: String
 
   prerequisites: String

--- a/src/graphql/typeDefs/dataTypes/session/keynote.graphql
+++ b/src/graphql/typeDefs/dataTypes/session/keynote.graphql
@@ -17,6 +17,10 @@ type Keynote implements EyesFront & Base @key(fields: "id") {
   speakers: [PublicProfile]
   "The type of session, informs union resolver of session object to return"
   type: SessionType
+  "The target audience for this session, professional, manager, kids, etc."
+  targetAudience: [TargetAudience]
+  "The target location for this session, in-person, etc."
+  targetLocation: TargetLocation
   "Session status. ENUM. E.g. accepted, submitted, etc. "
   status: Status
   "Full duration of session in minutes"
@@ -63,9 +67,7 @@ type Keynote implements EyesFront & Base @key(fields: "id") {
   isRecorded: Boolean
   "FUTURE: possible rating holder"
   rating: [Rating]
-  "type of audience session is targeted toward"
-  targetAudience: [TargetAudience]
-  "Main category declaration. e.g. professional, family, etc."
+  "Main category/track declaration. e.g. professional, family, etc."
   category: Category
 
   # Start Keynote-specific fields

--- a/src/graphql/typeDefs/dataTypes/session/keynote.graphql
+++ b/src/graphql/typeDefs/dataTypes/session/keynote.graphql
@@ -1,45 +1,74 @@
+"A session which establishes a main underlying theme or focus"
 type Keynote implements EyesFront & Base @key(fields: "id") {
+  # Start Base interface fields
+  "Session unique identifier"
   id: ID!
+  "Event id session is associated with"
   eventId: String!
+  "Session slug unique by eventId"
   slug: Slug!
+  "The session's title"
   title: String!
+  "A shorter more concise description"
   shortDescription: String!
+  "Primary interests category for the session"
   primaryCategory: SessionCategory
-  speakers: [PublicProfile!]!
-
+  "Session's associated speakers. Each will see session under their profile"
+  speakers: [PublicProfile]
+  "The type of session, informs union resolver of session object to return"
   type: SessionType
+  "Session status. ENUM. E.g. accepted, submitted, etc. "
   status: Status
+  "Full duration of session in minutes"
   durationInMinutes: Int
+  "Starting time of this session"
   startTime: Date
+  "Location of session, physical or virtual"
   location: String
-
+  "Tags to describe session"
   tags: [String]
+  "Reference materials for all"
   supportingArtifacts: [Artifact]
-  "members with public profiles who favorited session"
+  "Members with public profiles who favorited session"
   favoritedBy: [PublicProfile]
-  "total number of members who favorited, includes non-public in count too"
+  "Total number of members who favorited, includes non-public in count too"
   favoriteCount: Int
-  "communities (as slug) associated with session. initially same as event community"
+  "Communities (as slug) associated with session. initially same as event community"
   communities: [Slug]
   "Assets assigned to this session"
   assets: [Asset]
-
+  "Date time session created"
   createdAt: Date!
+  "Date time session last updated"
   lastUpdatedAt: Date!
+  "Admin-specific fields"
+  admin: SessionAdminFields
 
   # Start EyesFront interface fields
+  "a longer more verbose session description"
   longDescription: String
+  "why are you the best person to perform this session"
   whyAreYou: String
+  "other author comments regarding session"
   otherComments: String
+  "list of expected takeaways for attending this session"
   takeaways: [String]
+  "does the speaker(s) require mentorship on this session?"
   mentorship: Mentorship
+  "secondary interests categories for the session"
   secondaryCategory: [SessionCategory]
+  "does the speaker(s) allow session to be recorded"
   canRecord: Boolean
+  "session being recorded if set true"
   isRecorded: Boolean
+  "FUTURE: possible rating holder"
   rating: [Rating]
+  "type of audience session is targeted toward"
   targetAudience: [TargetAudience]
+  "Main category declaration. e.g. professional, family, etc."
   category: Category
 
-  # Keynote
+  # Start Keynote-specific fields
+  "Keynote agenda"
   agenda: String
 }

--- a/src/graphql/typeDefs/dataTypes/session/mySession.graphql
+++ b/src/graphql/typeDefs/dataTypes/session/mySession.graphql
@@ -12,7 +12,10 @@ type MySession @key(fields: "id") {
   type: SessionType
   category: Category
   durationInMinutes: Int
+  "The target audience for this session, professional, manager, kids, etc."
   targetAudience: [TargetAudience]
+  "The target location for this session, in-person, etc."
+  targetLocation: TargetLocation
   whyAreYou: String
   otherComments: String
 

--- a/src/graphql/typeDefs/dataTypes/session/openSpace.graphql
+++ b/src/graphql/typeDefs/dataTypes/session/openSpace.graphql
@@ -1,30 +1,45 @@
 type OpenSpace implements Base @key(fields: "id") {
+  # Start Base interface fields
+  "Session unique identifier"
   id: ID!
+  "Event id session is associated with"
   eventId: String!
+  "Session slug unique by eventId"
   slug: Slug!
+  "The session's title"
   title: String!
+  "A shorter more concise description"
   shortDescription: String!
+  "Primary interests category for the session"
   primaryCategory: SessionCategory
-  speakers: [PublicProfile!]!
-
+  "Session's associated speakers. Each will see session under their profile"
+  speakers: [PublicProfile]
+  "The type of session, informs union resolver of session object to return"
   type: SessionType
+  "Session status. ENUM. E.g. accepted, submitted, etc. "
   status: Status
+  "Full duration of session in minutes"
   durationInMinutes: Int
+  "Starting time of this session"
   startTime: Date
+  "Location of session, physical or virtual"
   location: String
-
+  "Tags to describe session"
   tags: [String]
   "Reference materials for all"
   supportingArtifacts: [Artifact]
-  "members with public profiles who favorited session"
+  "Members with public profiles who favorited session"
   favoritedBy: [PublicProfile]
-  "total number of members who favorited, includes non-public in count too"
+  "Total number of members who favorited, includes non-public in count too"
   favoriteCount: Int
-  "communities (as slug) associated with session. initially same as event community"
+  "Communities (as slug) associated with session. initially same as event community"
   communities: [Slug]
   "Assets assigned to this session"
   assets: [Asset]
-
+  "Date time session created"
   createdAt: Date!
+  "Date time session last updated"
   lastUpdatedAt: Date!
+  "Admin-specific fields"
+  admin: SessionAdminFields
 }

--- a/src/graphql/typeDefs/dataTypes/session/openSpace.graphql
+++ b/src/graphql/typeDefs/dataTypes/session/openSpace.graphql
@@ -16,6 +16,10 @@ type OpenSpace implements Base @key(fields: "id") {
   speakers: [PublicProfile]
   "The type of session, informs union resolver of session object to return"
   type: SessionType
+  "The target audience for this session, professional, manager, kids, etc."
+  targetAudience: [TargetAudience]
+  "The target location for this session, in-person, etc."
+  targetLocation: TargetLocation
   "Session status. ENUM. E.g. accepted, submitted, etc. "
   status: Status
   "Full duration of session in minutes"

--- a/src/graphql/typeDefs/dataTypes/session/panel.graphql
+++ b/src/graphql/typeDefs/dataTypes/session/panel.graphql
@@ -1,42 +1,70 @@
+"A session with multiple speakers who discuss topics"
 type Panel implements EyesFront & Base @key(fields: "id") {
+  # Start Base interface fields
+  "Session unique identifier"
   id: ID!
+  "Event id session is associated with"
   eventId: String!
+  "Session slug unique by eventId"
   slug: Slug!
+  "The session's title"
   title: String!
+  "A shorter more concise description"
   shortDescription: String!
+  "Primary interests category for the session"
   primaryCategory: SessionCategory
-  speakers: [PublicProfile!]!
-
+  "Session's associated speakers. Each will see session under their profile"
+  speakers: [PublicProfile]
+  "The type of session, informs union resolver of session object to return"
   type: SessionType
+  "Session status. ENUM. E.g. accepted, submitted, etc. "
   status: Status
+  "Full duration of session in minutes"
   durationInMinutes: Int
+  "Starting time of this session"
   startTime: Date
+  "Location of session, physical or virtual"
   location: String
-
+  "Tags to describe session"
   tags: [String]
+  "Reference materials for all"
   supportingArtifacts: [Artifact]
-  "members with public profiles who favorited session"
+  "Members with public profiles who favorited session"
   favoritedBy: [PublicProfile]
-  "total number of members who favorited, includes non-public in count too"
+  "Total number of members who favorited, includes non-public in count too"
   favoriteCount: Int
-  "communities (as slug) associated with session. initially same as event community"
+  "Communities (as slug) associated with session. initially same as event community"
   communities: [Slug]
   "Assets assigned to this session"
   assets: [Asset]
-
+  "Date time session created"
   createdAt: Date!
+  "Date time session last updated"
   lastUpdatedAt: Date!
+  "Admin-specific fields"
+  admin: SessionAdminFields
 
-  # Start Session interface fields
+  # Start EyesFront interface fields
+  "a longer more verbose session description"
   longDescription: String
+  "why are you the best person to perform this session"
   whyAreYou: String
+  "other author comments regarding session"
   otherComments: String
+  "list of expected takeaways for attending this session"
   takeaways: [String]
+  "does the speaker(s) require mentorship on this session?"
   mentorship: Mentorship
+  "secondary interests categories for the session"
   secondaryCategory: [SessionCategory]
+  "does the speaker(s) allow session to be recorded"
   canRecord: Boolean
+  "session being recorded if set true"
   isRecorded: Boolean
+  "FUTURE: possible rating holder"
   rating: [Rating]
+  "type of audience session is targeted toward"
   targetAudience: [TargetAudience]
+  "Main category declaration. e.g. professional, family, etc."
   category: Category
 }

--- a/src/graphql/typeDefs/dataTypes/session/panel.graphql
+++ b/src/graphql/typeDefs/dataTypes/session/panel.graphql
@@ -17,6 +17,10 @@ type Panel implements EyesFront & Base @key(fields: "id") {
   speakers: [PublicProfile]
   "The type of session, informs union resolver of session object to return"
   type: SessionType
+  "The target audience for this session, professional, manager, kids, etc."
+  targetAudience: [TargetAudience]
+  "The target location for this session, in-person, etc."
+  targetLocation: TargetLocation
   "Session status. ENUM. E.g. accepted, submitted, etc. "
   status: Status
   "Full duration of session in minutes"
@@ -63,8 +67,6 @@ type Panel implements EyesFront & Base @key(fields: "id") {
   isRecorded: Boolean
   "FUTURE: possible rating holder"
   rating: [Rating]
-  "type of audience session is targeted toward"
-  targetAudience: [TargetAudience]
-  "Main category declaration. e.g. professional, family, etc."
+  "Main category/track declaration. e.g. professional, family, etc."
   category: Category
 }

--- a/src/graphql/typeDefs/dataTypes/session/regular.graphql
+++ b/src/graphql/typeDefs/dataTypes/session/regular.graphql
@@ -17,6 +17,10 @@ type Regular implements EyesFront & Base @key(fields: "id") {
   speakers: [PublicProfile]
   "The type of session, informs union resolver of session object to return"
   type: SessionType
+  "The target audience for this session, professional, manager, kids, etc."
+  targetAudience: [TargetAudience]
+  "The target location for this session, in-person, etc."
+  targetLocation: TargetLocation
   "Session status. ENUM. E.g. accepted, submitted, etc. "
   status: Status
   "Full duration of session in minutes"
@@ -63,8 +67,6 @@ type Regular implements EyesFront & Base @key(fields: "id") {
   isRecorded: Boolean
   "FUTURE: possible rating holder"
   rating: [Rating]
-  "type of audience session is targeted toward"
-  targetAudience: [TargetAudience]
-  "Main category declaration. e.g. professional, family, etc."
+  "Main category/track declaration. e.g. professional, family, etc."
   category: Category
 }

--- a/src/graphql/typeDefs/dataTypes/session/regular.graphql
+++ b/src/graphql/typeDefs/dataTypes/session/regular.graphql
@@ -1,42 +1,70 @@
+"A regular session"
 type Regular implements EyesFront & Base @key(fields: "id") {
+  # Start Base interface fields
+  "Session unique identifier"
   id: ID!
+  "Event id session is associated with"
   eventId: String!
+  "Session slug unique by eventId"
   slug: Slug!
+  "The session's title"
   title: String!
+  "A shorter more concise description"
   shortDescription: String!
+  "Primary interests category for the session"
   primaryCategory: SessionCategory
-  speakers: [PublicProfile!]!
-
+  "Session's associated speakers. Each will see session under their profile"
+  speakers: [PublicProfile]
+  "The type of session, informs union resolver of session object to return"
   type: SessionType
+  "Session status. ENUM. E.g. accepted, submitted, etc. "
   status: Status
+  "Full duration of session in minutes"
   durationInMinutes: Int
+  "Starting time of this session"
   startTime: Date
+  "Location of session, physical or virtual"
   location: String
-
+  "Tags to describe session"
   tags: [String]
+  "Reference materials for all"
   supportingArtifacts: [Artifact]
-  "members with public profiles who favorited session"
+  "Members with public profiles who favorited session"
   favoritedBy: [PublicProfile]
-  "total number of members who favorited, includes non-public in count too"
+  "Total number of members who favorited, includes non-public in count too"
   favoriteCount: Int
-  "communities (as slug) associated with session. initially same as event community"
+  "Communities (as slug) associated with session. initially same as event community"
   communities: [Slug]
   "Assets assigned to this session"
   assets: [Asset]
-
+  "Date time session created"
   createdAt: Date!
+  "Date time session last updated"
   lastUpdatedAt: Date!
+  "Admin-specific fields"
+  admin: SessionAdminFields
 
-  # Start Session interface fields
+  # Start EyesFront interface fields
+  "a longer more verbose session description"
   longDescription: String
+  "why are you the best person to perform this session"
   whyAreYou: String
+  "other author comments regarding session"
   otherComments: String
+  "list of expected takeaways for attending this session"
   takeaways: [String]
+  "does the speaker(s) require mentorship on this session?"
   mentorship: Mentorship
+  "secondary interests categories for the session"
   secondaryCategory: [SessionCategory]
+  "does the speaker(s) allow session to be recorded"
   canRecord: Boolean
+  "session being recorded if set true"
   isRecorded: Boolean
+  "FUTURE: possible rating holder"
   rating: [Rating]
+  "type of audience session is targeted toward"
   targetAudience: [TargetAudience]
+  "Main category declaration. e.g. professional, family, etc."
   category: Category
 }

--- a/src/graphql/typeDefs/dataTypes/session/sessionAdminFields.graphql
+++ b/src/graphql/typeDefs/dataTypes/session/sessionAdminFields.graphql
@@ -1,0 +1,4 @@
+type SessionAdminFields {
+  "a session's speakers"
+  speakers: [Profile]! @auth(requires: "admin")
+}

--- a/src/graphql/typeDefs/dataTypes/session/workshop.graphql
+++ b/src/graphql/typeDefs/dataTypes/session/workshop.graphql
@@ -1,48 +1,76 @@
+"Hands-on session types used for training and other interactive interactions"
 type Workshop implements EyesFront & Base @key(fields: "id") {
+  # Start Base interface fields
+  "Session unique identifier"
   id: ID!
+  "Event id session is associated with"
   eventId: String!
+  "Session slug unique by eventId"
   slug: Slug!
+  "The session's title"
   title: String!
+  "A shorter more concise description"
   shortDescription: String!
+  "Primary interests category for the session"
   primaryCategory: SessionCategory
-  speakers: [PublicProfile!]!
-
+  "Session's associated speakers. Each will see session under their profile"
+  speakers: [PublicProfile]
+  "The type of session, informs union resolver of session object to return"
   type: SessionType
+  "Session status. ENUM. E.g. accepted, submitted, etc. "
   status: Status
+  "Full duration of session in minutes"
   durationInMinutes: Int
+  "Starting time of this session"
   startTime: Date
+  "Location of session, physical or virtual"
   location: String
-
+  "Tags to describe session"
   tags: [String]
+  "Reference materials for all"
   supportingArtifacts: [Artifact]
-  "members with public profiles who favorited session"
+  "Members with public profiles who favorited session"
   favoritedBy: [PublicProfile]
-  "total number of members who favorited, includes non-public in count too"
+  "Total number of members who favorited, includes non-public in count too"
   favoriteCount: Int
-  "communities (as slug) associated with session. initially same as event community"
+  "Communities (as slug) associated with session. initially same as event community"
   communities: [Slug]
   "Assets assigned to this session"
   assets: [Asset]
-
+  "Date time session created"
   createdAt: Date!
+  "Date time session last updated"
   lastUpdatedAt: Date!
+  "Admin-specific fields"
+  admin: SessionAdminFields
 
-  # Start Session interface fields
+  # Start EyesFront interface fields
+  "a longer more verbose session description"
   longDescription: String
+  "why are you the best person to perform this session"
   whyAreYou: String
+  "other author comments regarding session"
   otherComments: String
+  "list of expected takeaways for attending this session"
   takeaways: [String]
+  "does the speaker(s) require mentorship on this session?"
   mentorship: Mentorship
+  "secondary interests categories for the session"
   secondaryCategory: [SessionCategory]
+  "does the speaker(s) allow session to be recorded"
   canRecord: Boolean
+  "session being recorded if set true"
   isRecorded: Boolean
+  "FUTURE: possible rating holder"
   rating: [Rating]
+  "type of audience session is targeted toward"
   targetAudience: [TargetAudience]
+  "Main category declaration. e.g. professional, family, etc."
   category: Category
 
-  # Workshop specific
-  "items and tasks to be done PRIOR to attending session"
+  # Workshop-specific fields
+  "Items and tasks to be done PRIOR to attending session"
   prerequisites: String
-  "detailed agenda of workshop"
+  "Detailed agenda of workshop"
   agenda: String
 }

--- a/src/graphql/typeDefs/dataTypes/session/workshop.graphql
+++ b/src/graphql/typeDefs/dataTypes/session/workshop.graphql
@@ -17,6 +17,10 @@ type Workshop implements EyesFront & Base @key(fields: "id") {
   speakers: [PublicProfile]
   "The type of session, informs union resolver of session object to return"
   type: SessionType
+  "The target audience for this session, professional, manager, kids, etc."
+  targetAudience: [TargetAudience]
+  "The target location for this session, in-person, etc."
+  targetLocation: TargetLocation
   "Session status. ENUM. E.g. accepted, submitted, etc. "
   status: Status
   "Full duration of session in minutes"
@@ -63,9 +67,7 @@ type Workshop implements EyesFront & Base @key(fields: "id") {
   isRecorded: Boolean
   "FUTURE: possible rating holder"
   rating: [Rating]
-  "type of audience session is targeted toward"
-  targetAudience: [TargetAudience]
-  "Main category declaration. e.g. professional, family, etc."
+  "Main category/track declaration. e.g. professional, family, etc."
   category: Category
 
   # Workshop-specific fields

--- a/src/graphql/typeDefs/queries/adminSessions.graphql
+++ b/src/graphql/typeDefs/queries/adminSessions.graphql
@@ -1,0 +1,6 @@
+type AdminSessionsQuery {
+  "Gets all accepted sessions for a given event. Used for scheduling"
+  pullSchedule(eventId: ID!): [TheSessions]
+  "Get all sessions with filters. DEFAULTS: status=APPROVED"
+  all(eventId: ID, status: [Status], orderBy: SessionOrderBy): [TheSessions]
+}

--- a/src/graphql/typeDefs/queries/sessionsQuery.graphql
+++ b/src/graphql/typeDefs/queries/sessionsQuery.graphql
@@ -12,4 +12,6 @@ type SessionsQuery {
     pageSize: Int
     cursor: String
   ): PagedAcceptedSession
+  "Admin-centric queries"
+  admin: AdminSessionsQuery @auth(requires: "admin")
 }


### PR DESCRIPTION
    Add new admin field type to session types
    Allows admin field views from the same types
    Directive was not working on session type level, admin permissions set at admin field level
    Clean up session fields and descriptions across all session types

    Add admin query path
    Add all query with filters for eventId and status

    New Session field, targetLocation for denoting on-the-line, in-person or either
    replace missing TargetAudience from Base interface
    other clean-up