### PR TITLE
fix email notifications for non-daily events

### DIFF
--- a/src/graphql/resolvers/mutations/sessionCreate.js
+++ b/src/graphql/resolvers/mutations/sessionCreate.js
@@ -28,11 +28,7 @@ function sendUserEvent({
   userEvents,
   user,
 }) {
-  if (
-    (sessionResults.status === 'SUBMITTED' ||
-      sessionResults.status === 'ACCEPTED') &&
-    sessionResults.startTime
-  ) {
+  if (['SUBMITTED', 'ACCEPTED'].includes(sessionResults.status)) {
     userEvents.emit('sessionCreated', {
       user: {
         ...user,

--- a/src/graphql/resolvers/mutations/sessionUpdate.js
+++ b/src/graphql/resolvers/mutations/sessionUpdate.js
@@ -81,7 +81,11 @@ function sendUserEvent({
     updatedSession.status === 'SUBMITTED'
   ) {
     eventTitle = 'sessionCreated';
-  } else if (updatedSession.status === 'ACCEPTED') {
+  } else if (
+    updatedSession.status === 'ACCEPTED' ||
+    (originalSession.status === 'SUBMITTED' &&
+      updatedSession.status === 'SUBMITTED')
+  ) {
     eventTitle = 'sessionUpdated';
   } else if (updatedSession.status === 'CANCELLED') {
     eventTitle = 'sessionCancelled';


### PR DESCRIPTION
email template selected based on event type, `['MULTI_DAY', 'HYBRID_MULTI_DAY', 'SINGLE_DAY']` vs. `['ONLINE', 'DAILY']`
Cleaned up create and update logic for triggering event emitter. 
temporarily suppressing shared calendar entry creation and update for `['MULTI_DAY', 'HYBRID_MULTI_DAY', 'SINGLE_DAY']` events.

