### PR TITLE
Replace local event firestore dataStore

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "that-api-sessions",
-  "version": "1.11.3",
+  "version": "1.12.0",
   "description": "THAT Conference's Sessions Micro Service.",
   "main": "index.js",
   "engines": {

--- a/src/dataSources/cloudFirestore/event.js
+++ b/src/dataSources/cloudFirestore/event.js
@@ -1,3 +1,4 @@
+// ** DEPRECATED **
 import debug from 'debug';
 
 const dlog = debug('that:api:sessions:datasources:firebase:event');

--- a/src/graphql/resolvers/mutations/adminSessionCreate.js
+++ b/src/graphql/resolvers/mutations/adminSessionCreate.js
@@ -1,10 +1,11 @@
 /* eslint-disable import/prefer-default-export */
 import debug from 'debug';
+import { dataSources } from '@thatconference/api';
 
 import sessionStore from '../../../dataSources/cloudFirestore/session';
 import memberStore from '../../../dataSources/cloudFirestore/member';
-import eventStore from '../../../dataSources/cloudFirestore/event';
 
+const eventStore = dataSources.cloudFirestore.event;
 const dlog = debug('that:api:sessions:mutation:AdminSessionCreate');
 
 async function createNewSession({ eventId, user, session, firestore }) {
@@ -14,7 +15,7 @@ async function createNewSession({ eventId, user, session, firestore }) {
       session,
     }),
     memberStore(firestore).find(user.sub),
-    eventStore(firestore).getEvent(eventId),
+    eventStore(firestore).get(eventId),
   ]);
 
   return { sessionResults, userResults, eventResults };

--- a/src/graphql/resolvers/mutations/adminSessionUpdate.js
+++ b/src/graphql/resolvers/mutations/adminSessionUpdate.js
@@ -1,9 +1,10 @@
 import debug from 'debug';
+import { dataSources } from '@thatconference/api';
 
 import sessionStore from '../../../dataSources/cloudFirestore/session';
 import memberStore from '../../../dataSources/cloudFirestore/member';
-import eventStore from '../../../dataSources/cloudFirestore/event';
 
+const eventStore = dataSources.cloudFirestore.event;
 const dlog = debug('that:api:sessions:mutation:AdminSessionUpdate');
 
 async function updateSession({
@@ -19,7 +20,7 @@ async function updateSession({
       session,
     }),
     memberStore(firestore).find(originalSession.speakers[0]),
-    eventStore(firestore).getEvent(eventId),
+    eventStore(firestore).get(eventId),
   ]);
 
   return { updatedSession, speakerResults, eventResults };

--- a/src/graphql/resolvers/mutations/sessionCreate.js
+++ b/src/graphql/resolvers/mutations/sessionCreate.js
@@ -1,9 +1,11 @@
 /* eslint-disable import/prefer-default-export */
 import debug from 'debug';
+import { dataSources } from '@thatconference/api';
 
 import sessionStore from '../../../dataSources/cloudFirestore/session';
 import memberStore from '../../../dataSources/cloudFirestore/member';
-import eventStore from '../../../dataSources/cloudFirestore/event';
+
+const eventStore = dataSources.cloudFirestore.event;
 
 const dlog = debug('that:api:sessions:mutation:SessionCreate');
 
@@ -15,7 +17,7 @@ async function createNewSession({ eventId, user, session, firestore }) {
       session,
     }),
     memberStore(firestore).find(user.sub),
-    eventStore(firestore).getEvent(eventId),
+    eventStore(firestore).get(eventId),
   ]);
 
   return { sessionResults, userResults, eventResults };

--- a/src/graphql/resolvers/mutations/sessionUpdate.js
+++ b/src/graphql/resolvers/mutations/sessionUpdate.js
@@ -1,12 +1,13 @@
 /* eslint-disable import/prefer-default-export */
 import debug from 'debug';
+import { dataSources } from '@thatconference/api';
 import { ForbiddenError } from 'apollo-server-express';
 
 import sessionStore from '../../../dataSources/cloudFirestore/session';
 import memberStore from '../../../dataSources/cloudFirestore/member';
-import eventStore from '../../../dataSources/cloudFirestore/event';
 import checkMemberCanMutate from '../../../lib/checkMemberCanMutate';
 
+const eventStore = dataSources.cloudFirestore.event;
 const dlog = debug('that:api:sessions:mutation:SessionUpdate');
 const clearProtectedFieldStatus = [
   'SUBMITTED',
@@ -23,7 +24,7 @@ async function updateSession({ eventId, sessionId, user, session, firestore }) {
       session,
     }),
     memberStore(firestore).find(user.sub),
-    eventStore(firestore).getEvent(eventId),
+    eventStore(firestore).get(eventId),
   ]);
 
   return { updatedSession, userResults, eventResults };

--- a/src/graphql/resolvers/mutations/sessions.js
+++ b/src/graphql/resolvers/mutations/sessions.js
@@ -1,8 +1,8 @@
 /* eslint-disable import/prefer-default-export */
 import debug from 'debug';
+import { dataSources } from '@thatconference/api';
 
-import eventStore from '../../../dataSources/cloudFirestore/event';
-
+const eventStore = dataSources.cloudFirestore.event;
 const dlog = debug('that:api:sessions:mutation:SessionsMutation');
 
 export const fieldResolvers = {
@@ -19,7 +19,7 @@ export const fieldResolvers = {
 
     voting: async (_, { eventId }, { dataSources: { firestore } }) => {
       dlog('voting');
-      const { isVotingOpen } = await eventStore(firestore).getEvent(eventId);
+      const { isVotingOpen } = await eventStore(firestore).get(eventId);
 
       if (!isVotingOpen) throw new Error('voting is currently closed');
 

--- a/src/graphql/resolvers/queries/me.js
+++ b/src/graphql/resolvers/queries/me.js
@@ -1,9 +1,10 @@
 import debug from 'debug';
+import { dataSources } from '@thatconference/api';
 
 import sessionStore from '../../../dataSources/cloudFirestore/session';
-import eventStore from '../../../dataSources/cloudFirestore/event';
 import favoriteStore from '../../../dataSources/cloudFirestore/favorite';
 
+const eventStore = dataSources.cloudFirestore.event;
 const dlog = debug('that:api:sessions:me');
 
 export const fieldResolvers = {
@@ -21,7 +22,7 @@ export const fieldResolvers = {
       });
     },
     voting: async (_, { eventId }, { dataSources: { firestore } }) => {
-      const { isVotingOpen } = await eventStore(firestore).getEvent(eventId);
+      const { isVotingOpen } = await eventStore(firestore).get(eventId);
 
       return { eventId, isVotingOpen };
     },

--- a/src/lib/checkMemberCanMutate.js
+++ b/src/lib/checkMemberCanMutate.js
@@ -1,9 +1,10 @@
 import debug from 'debug';
+import { dataSources } from '@thatconference/api';
 import memberLib from '../dataSources/cloudFirestore/member';
-import eventLib from '../dataSources/cloudFirestore/event';
 import orderLib from '../dataSources/cloudFirestore/order';
 import constants from '../constants';
 
+const eventLib = dataSources.cloudFirestore.event;
 const dlog = debug('that:api:sessions:checkMemberCanMutate');
 
 export default function checkMemberCanMutate({ user, eventId, firestore }) {
@@ -21,7 +22,7 @@ export default function checkMemberCanMutate({ user, eventId, firestore }) {
   }
 
   const memberFunc = memberStore.find(memberId);
-  const eventFunc = eventStore.getEvent(eventId);
+  const eventFunc = eventStore.get(eventId);
   const allocationFunc = orderStore.findMeOrderAllocationsForEvent({
     memberId,
     eventId,


### PR DESCRIPTION
Replace local event firestore dataStore with version from that-api, all instances of use for `getEvent`.