### PR TITLE
Fixes og-image issue on non-approved sessions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "that-api-sessions",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "THAT Conference Sessions Service.",
   "main": "index.js",
   "engines": {

--- a/src/events/admin.js
+++ b/src/events/admin.js
@@ -298,6 +298,11 @@ export default function adminEvents(postmark) {
 
   function setOgImage({ session }) {
     dlog('call setOgImage');
+    if (session.status !== 'ACCEPTED') {
+      dlog('session not accepted, leaving setOgImage');
+      return;
+    }
+
     callOgImage(session.id)
       .then(res => dlog('setOgImage result: %o', res))
       .catch(e => process.nextTick(() => adminEventEmitter.emit('error', e)));

--- a/src/events/user.js
+++ b/src/events/user.js
@@ -292,6 +292,11 @@ function userEvents(postmark) {
 
   function setOgImage({ session }) {
     dlog('call setOgImage');
+    if (session.status !== 'ACCEPTED') {
+      dlog('session not accepted, leaving setOgImage');
+      return;
+    }
+
     callOgImage(session.id)
       .then(res => dlog('setOgImage result: %o', res))
       .catch(e => process.nextTick(() => userEventEmitter.emit('error', e)));


### PR DESCRIPTION
v2.4.3
Only sends request to og-image function if the session is `APPROVED`