### PR TITLE
Triggers deploy which was missed while GitHub was degraded

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "that-api-sessions",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "THAT Conference Sessions Service.",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
v2.6.1

Deploy from merge of pr #178 didn't trigger. GitHub having issues at the time. This PR forces a new deploy.