### PR TITLE
add family to session category

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "that-api-sessions",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "THAT Conference Sessions Service.",
   "main": "index.js",
   "engines": {

--- a/src/graphql/typeDefs/dataTypes/enums/sessionCategory.graphql
+++ b/src/graphql/typeDefs/dataTypes/enums/sessionCategory.graphql
@@ -14,6 +14,8 @@ enum SessionCategory {
   DESIGN_UX
   "DevOps"
   DEV_OPS
+  "Family"
+  FAMILY
   "Game Development"
   GAME_DEVELOPMENT
   "Infrastructure"

--- a/src/graphql/typeDefs/dataTypes/enums/status.graphql
+++ b/src/graphql/typeDefs/dataTypes/enums/status.graphql
@@ -6,7 +6,7 @@ enum Status {
   SUBMITTED
   "Accepted"
   ACCEPTED
-  "Pending accepted status"
+  "Pending Accepted"
   PENDING_ACCEPTED
   "Not Accepted"
   NOT_ACCEPTED


### PR DESCRIPTION
v3.2.0
Add `FAMILY` to enum SessionCategory
This enum is not located in any other sub-graph