### PR TITLE
fix: use admin event emitter on admin session create

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "that-api-sessions",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "THAT Conference Sessions Service.",
   "main": "index.js",
   "engines": {

--- a/src/events/user.js
+++ b/src/events/user.js
@@ -400,12 +400,6 @@ function userEvents(postmark) {
   userEventEmitter.on('sessionUpdated', setOgImage);
   userEventEmitter.on('sessionUpdated', sendOrbitLoveActivtyOnUpdate);
   userEventEmitter.on('sessionCancelled', cancelSharedCalendar);
-  // on admin events
-  userEventEmitter.on('adminSessionCreated', insertSharedCalendar);
-  userEventEmitter.on('adminSessionCreated', setOgImage);
-  userEventEmitter.on('adminSessionUpdated', updateSharedCalendar);
-  userEventEmitter.on('adminSessionUpdated', setOgImage);
-  userEventEmitter.on('adminSessionCancelled', cancelSharedCalendar);
 
   return userEventEmitter;
 }

--- a/src/graphql/resolvers/mutations/adminSessionCreate.js
+++ b/src/graphql/resolvers/mutations/adminSessionCreate.js
@@ -26,7 +26,7 @@ function sendUserEvent({
   sessionResults,
   userResults,
   eventResults,
-  userEvents,
+  adminEvents,
   user,
 }) {
   if (
@@ -34,7 +34,7 @@ function sendUserEvent({
       sessionResults.status === 'ACCEPTED') &&
     sessionResults.startTime
   ) {
-    userEvents.emit('adminSessionCreated', {
+    adminEvents.emit('sessionCreated', {
       user: {
         ...user,
         ...userResults,
@@ -62,7 +62,7 @@ export const fieldResolvers = {
       {
         dataSources: {
           firestore,
-          events: { userEvents, graphCdnEvents },
+          events: { adminEvents, graphCdnEvents },
         },
         user,
       },
@@ -79,7 +79,7 @@ export const fieldResolvers = {
         sessionResults,
         userResults,
         eventResults,
-        userEvents,
+        adminEvents,
         user,
       });
       sendGraphCdnEvent({ graphCdnEvents, sessionResults });
@@ -92,7 +92,7 @@ export const fieldResolvers = {
       {
         dataSources: {
           firestore,
-          events: { userEvents, graphCdnEvents },
+          events: { adminEvents, graphCdnEvents },
         },
         user,
       },
@@ -109,7 +109,7 @@ export const fieldResolvers = {
         sessionResults,
         userResults,
         eventResults,
-        userEvents,
+        adminEvents,
         user,
       });
       sendGraphCdnEvent({ graphCdnEvents, sessionResults });
@@ -122,7 +122,7 @@ export const fieldResolvers = {
       {
         dataSources: {
           firestore,
-          events: { userEvents, graphCdnEvents },
+          events: { adminEvents, graphCdnEvents },
         },
         user,
       },
@@ -139,7 +139,7 @@ export const fieldResolvers = {
         sessionResults,
         userResults,
         eventResults,
-        userEvents,
+        adminEvents,
         user,
       });
       sendGraphCdnEvent({ graphCdnEvents, sessionResults });
@@ -152,7 +152,7 @@ export const fieldResolvers = {
       {
         dataSources: {
           firestore,
-          events: { userEvents, graphCdnEvents },
+          events: { adminEvents, graphCdnEvents },
         },
         user,
       },
@@ -169,7 +169,7 @@ export const fieldResolvers = {
         sessionResults,
         userResults,
         eventResults,
-        userEvents,
+        adminEvents,
         user,
       });
       sendGraphCdnEvent({ graphCdnEvents, sessionResults });
@@ -182,7 +182,7 @@ export const fieldResolvers = {
       {
         dataSources: {
           firestore,
-          events: { userEvents, graphCdnEvents },
+          events: { adminEvents, graphCdnEvents },
         },
         user,
       },
@@ -199,7 +199,7 @@ export const fieldResolvers = {
         sessionResults,
         userResults,
         eventResults,
-        userEvents,
+        adminEvents,
         user,
       });
       sendGraphCdnEvent({ graphCdnEvents, sessionResults });


### PR DESCRIPTION
## v4.4.0

Fix: use admin event emitter on admin create session event. It was using an "admin" trigger in the user emitter"

Verified that `adminSessionCreated`, `adminSessionUpdated`, and `adminSessionCancelled` are no longer called