### PR TITLE
refactor: timing on open_space channel created vs batch created

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "that-api-sessions",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "THAT Conference Sessions Service.",
   "main": "index.js",
   "engines": {

--- a/src/lib/__test__/findDateAtNextHour.test.js
+++ b/src/lib/__test__/findDateAtNextHour.test.js
@@ -1,49 +1,36 @@
 import { findDateAtNextHour } from '../findDateAtNextHour';
-import dayjs from 'dayjs';
 import mockDate from 'mockdate';
 
 const tests = [
   {
     now: '2023-10-11T10:10:10',
     for: 8,
-    expect: dayjs('2023-10-11T10:10:10')
-      .add(1, 'day')
-      .hour(8)
-      .startOf('hour')
-      .toDate(),
+    expect: new Date('2023-10-12T08:00:00'),
   },
   {
     now: '2023-10-11T10:10:10',
     for: 12,
-    expect: dayjs('2023-10-11T10:10:10').hour(12).startOf('hour').toDate(),
+    expect: new Date('2023-10-11T12:00:00'),
   },
   {
     now: '2023-10-11T10:10:10',
     for: 10,
-    expect: dayjs('2023-10-11T10:10:10')
-      .add(1, 'day')
-      .hour(10)
-      .startOf('hour')
-      .toDate(),
+    expect: new Date('2023-10-12T10:00:00'),
   },
   {
     now: '2023-10-11T11:00:00',
     for: 11,
-    expect: dayjs('2023-10-11T11:00:00').hour(11).startOf('hour').toDate(),
+    expect: new Date('2023-10-11T11:00:00'),
   },
   {
     now: '2023-10-11T11:00:01',
     for: 11,
-    expect: dayjs('2023-10-11T11:00:00')
-      .add(1, 'day')
-      .hour(11)
-      .startOf('hour')
-      .toDate(),
+    expect: new Date('2023-10-12T11:00:00'),
   },
   {
     now: '2023-10-11T10:59:59',
     for: 11,
-    expect: dayjs('2023-10-11T10:59:59').hour(11).startOf('hour').toDate(),
+    expect: new Date('2023-10-11T11:00:00'),
   },
 ];
 

--- a/src/lib/callThatJoinDiscordBot.js
+++ b/src/lib/callThatJoinDiscordBot.js
@@ -102,7 +102,9 @@ export function createVoiceChannelForSession({ session }) {
   // startTime < time of next batch
   // time of next batch (assuming batches are at 08:00)
   const sessionStart = dayjs(session.startTime);
-  const nextBatchTime = dayjs(findDateAtNextHour(8));
+  let nextBatchTime = dayjs(findDateAtNextHour(8));
+  // skip to next batch so activities are listed longer (at least 24 hours)
+  nextBatchTime = nextBatchTime.add(1, 'day');
   if (
     session.status === 'ACCEPTED' &&
     session.type === 'OPEN_SPACE' &&


### PR DESCRIPTION
## v4.5.1

- refactor channel creation so channel created now threshold is larger. 

It's 10/1 at 16:00 and an open_space is created for 10/2 at 10:00
before:
the session would not be created now, but at next batch 10/2 at 08:00 (only having the session listed for 2 hours)
now:
the session is created immediately, listing it now in discord. (providing 18 hours of being listed)

