### PR TITLE
update that-api version to include graphcdn default change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "that-api-sessions",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "that-api-sessions",
-      "version": "4.8.1",
+      "version": "4.8.2",
       "license": "GPL-3.0",
       "dependencies": {
         "@apollo/server": "^4.10.0",
@@ -17,7 +17,7 @@
         "@graphql-tools/merge": "^9.0.1",
         "@graphql-tools/utils": "^10.0.12",
         "@sentry/node": "^7.118.0",
-        "@thatconference/api": "~4.5.0",
+        "@thatconference/api": "~4.5.1",
         "@thatconference/schema": "^4.1.0",
         "base32-encode": "~1.2.0",
         "body-parser": "^1.20.2",
@@ -3868,9 +3868,9 @@
       }
     },
     "node_modules/@thatconference/api": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@thatconference/api/-/api-4.5.0.tgz",
-      "integrity": "sha512-K4mbZWZWQoJZNPrQSbT/VqiETVX5WzN0hp1oaCFtqpqadMAxquQtZV0GWliPp/ko400jkx515X6FoOiRcmu/zw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@thatconference/api/-/api-4.5.1.tgz",
+      "integrity": "sha512-EJFO7iVIkRBf5pIbvzYjCO/SbuYZaWtsq+C12dnqgfdQ79us8+LP/Xg+546ATbAfLE2CWjz1qmHKmm7IK2uqXQ==",
       "dependencies": {
         "@adobe/node-fetch-retry": "^2.2.0",
         "@google-cloud/firestore": "^7.1.0",
@@ -16563,9 +16563,9 @@
       }
     },
     "@thatconference/api": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@thatconference/api/-/api-4.5.0.tgz",
-      "integrity": "sha512-K4mbZWZWQoJZNPrQSbT/VqiETVX5WzN0hp1oaCFtqpqadMAxquQtZV0GWliPp/ko400jkx515X6FoOiRcmu/zw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@thatconference/api/-/api-4.5.1.tgz",
+      "integrity": "sha512-EJFO7iVIkRBf5pIbvzYjCO/SbuYZaWtsq+C12dnqgfdQ79us8+LP/Xg+546ATbAfLE2CWjz1qmHKmm7IK2uqXQ==",
       "requires": {
         "@adobe/node-fetch-retry": "^2.2.0",
         "@google-cloud/firestore": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "that-api-sessions",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "description": "THAT Conference Sessions Service.",
   "main": "index.js",
   "engines": {
@@ -28,7 +28,7 @@
     "@graphql-tools/merge": "^9.0.1",
     "@graphql-tools/utils": "^10.0.12",
     "@sentry/node": "^7.118.0",
-    "@thatconference/api": "~4.5.0",
+    "@thatconference/api": "~4.5.1",
     "@thatconference/schema": "^4.1.0",
     "base32-encode": "~1.2.0",
     "body-parser": "^1.20.2",


### PR DESCRIPTION
## v4.8.2

update that-api version to include graphcdn default change

Update was also made to production secrets for stellate URL reference